### PR TITLE
Assets target lang

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,0 +1,29 @@
+"use sctrict";
+
+const csharp = {
+  lang: "C#",
+  extension: "cshtml"
+};
+
+const vb = {
+  lang: "VB",
+  extension: "vbhtml"
+};
+
+class Configuration {
+  constructor(target, rules) {
+    this.target =
+      typeof target === "string" && `${target}`.toUpperCase() == vb.lang
+        ? vb.lang
+        : csharp.lang;
+    this.extension = this.target === vb.lang ? vb.extension : csharp.extension;
+    if (rules)
+      rules.forEach(rule => {
+        if (!rule.output.extension) {
+          rule.output.extension = this.extension;
+        }
+      });
+  }
+}
+
+module.exports = Configuration;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,4 +1,4 @@
-"use sctrict";
+"use strict";
 
 const csharp = {
   lang: "C#",
@@ -10,19 +10,35 @@ const vb = {
   extension: "vbhtml"
 };
 
+let _rules;
+
 class Configuration {
-  constructor(target, rules) {
-    this.target =
-      typeof target === "string" && `${target}`.toUpperCase() == vb.lang
-        ? vb.lang
-        : csharp.lang;
+  constructor(opts, rules) {
+    const options = typeof opts === "object" ? opts : {};
+    this.target = this._getTargetLang(options);
     this.extension = this.target === vb.lang ? vb.extension : csharp.extension;
-    if (rules)
-      rules.forEach(rule => {
-        if (!rule.output.extension) {
-          rule.output.extension = this.extension;
-        }
-      });
+    this.rules = rules;
+  }
+
+  get rules() {
+    return _rules.map(rule => {
+      rule.output = rule.output || {};
+      if (!rule.output.extension) {
+        rule.output.extension = this.extension;
+      }
+      return rule;
+    });
+  }
+
+  set rules(values) {
+    _rules = Array.isArray(values) ? values : [];
+  }
+
+  _getTargetLang(options) {
+    const target = options.target || "C#";
+    return typeof target === "string" && `${target}`.toUpperCase() == vb.lang
+      ? vb.lang
+      : csharp.lang;
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,12 +1,12 @@
 "use strict";
 
 const TemplatedAssetsWebpackPlugin = require("templated-assets-webpack-plugin");
+const Configuration = require("./configuration");
 
 class RazorPartialViewsWebpackPlugin extends TemplatedAssetsWebpackPlugin {
   constructor(opts) {
     super(opts);
-    const rules = this.rules.rules;
-    rules.forEach(rule => (rule.output.extension = "cshtml"));
+    const config = new Configuration(opts.target, this.rules.rules);
   }
 
   apply(compiler) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,9 +4,10 @@ const TemplatedAssetsWebpackPlugin = require("templated-assets-webpack-plugin");
 const Configuration = require("./configuration");
 
 class RazorPartialViewsWebpackPlugin extends TemplatedAssetsWebpackPlugin {
-  constructor(opts) {
-    super(opts);
-    const config = new Configuration(opts.target, this.rules.rules);
+  constructor(options) {
+    super(options);
+    const config = new Configuration(options, this.rules.rules);
+    this.rules.rules = config.rules;
   }
 
   apply(compiler) {

--- a/test/configuration-init-test.js
+++ b/test/configuration-init-test.js
@@ -10,14 +10,16 @@ test("default to target C#", t => {
 });
 
 test("can set target in anycase", t => {
-  const config = new Configuration("vB");
+  const options = { target: "vB" };
+  const config = new Configuration(options);
 
   t.is(config.target, "VB");
   t.is(config.extension, "vbhtml");
 });
 
 test("can set target VB", t => {
-  const config = new Configuration("VB");
+  const options = { target: "VB" };
+  const config = new Configuration(options);
 
   t.is(config.target, "VB");
   t.is(config.extension, "vbhtml");

--- a/test/configuration-init-test.js
+++ b/test/configuration-init-test.js
@@ -1,0 +1,24 @@
+import test from "ava";
+
+import Configuration from "../lib/configuration";
+
+test("default to target C#", t => {
+  const config = new Configuration();
+
+  t.is(config.target, "C#");
+  t.is(config.extension, "cshtml");
+});
+
+test("can set target in anycase", t => {
+  const config = new Configuration("vB");
+
+  t.is(config.target, "VB");
+  t.is(config.extension, "vbhtml");
+});
+
+test("can set target VB", t => {
+  const config = new Configuration("VB");
+
+  t.is(config.target, "VB");
+  t.is(config.extension, "vbhtml");
+});


### PR DESCRIPTION
Added support for targeting either C# or VB, with the former as default (and fallback); issue https://github.com/jouni-kantola/razor-partial-views-webpack-plugin/issues/3.