### PR TITLE
Extend header with module and usings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,27 @@
 Plugin for generating ASP.NET Razor partial views for assets built with webpack.
 
 [![Build Status](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin.svg?branch=master)](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin)
+
+## Example configuration
+```javascript
+module.exports = {
+  target: "C#", // C# or VB
+  rules: [
+    {
+      name: "manifest", // match by name
+      test: /manifest.*\.js$/, // ...or with regex
+      template: {
+        header: () => "top of view", // prepend to view
+        using: ["namespace1", "namespace2"], // if needed, usings used in view
+        model: "MyViewModel", // view's model
+        footer: () => "bottom of view", // append to view
+        path: path.join(__dirname, "tmpl/inline.tmpl"), // if needed, custom template
+        replace: "##HULAHULA##" // if custom template, what to replace
+      },
+      output: {
+        inline: true // href, defer, async, inline
+      }
+    }
+  ]
+};
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Plugin for generating ASP.NET Razor partial views for assets built with webpack.
 ## Example configuration
 ```javascript
 module.exports = {
-  target: "C#", // C# or VB
+  target: "chsharp", // csharp or vb
   rules: [
     {
       name: "manifest", // match by name

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -36,12 +36,20 @@ class Configuration {
       }
 
       if (rule.template) {
-        if (rule.template.header) {
-          const configuredHeader = rule.template.header;
+        const configuredHeader =
+          typeof rule.template.header === "function"
+            ? rule.template.header()
+            : rule.template.header;
+
+        const header = configuredHeader ? `${configuredHeader}\n` : "";
+
+        const model = rule.template.model ? `@${rule.template.model}\n` : "";
+
+        const mergedHeader = `${header}${model}`;
+
+        if (mergedHeader) {
           rule.template.header = () => {
-            return typeof configuredHeader === "function"
-              ? configuredHeader()
-              : configuredHeader;
+            return mergedHeader;
           };
         }
       }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -2,12 +2,18 @@
 
 const csharp = {
   lang: "C#",
-  extension: "cshtml"
+  extension: "cshtml",
+  attr: {
+    model: "@model"
+  }
 };
 
 const vb = {
   lang: "VB",
-  extension: "vbhtml"
+  extension: "vbhtml",
+  attr: {
+    model: "@ModelType"
+  }
 };
 
 let _rules;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -43,11 +43,23 @@ class Configuration {
 
         const header = configuredHeader ? `${configuredHeader}\n` : "";
 
+        const configuredUsings = Array.isArray(rule.template.usings)
+          ? rule.template.usings
+          : [];
+
+        const usings = configuredUsings.length
+          ? configuredUsings.reduce(
+              (usings, using) =>
+                `${usings}${this.target.attr.using} ${using}\n`,
+              ""
+            )
+          : "";
+
         const model = rule.template.model
           ? `${this.target.attr.model} ${rule.template.model}\n`
           : "";
 
-        const mergedHeader = `${header}${model}`;
+        const mergedHeader = `${header}${usings}${model}`;
 
         if (mergedHeader) {
           rule.template.header = () => {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,20 +1,21 @@
 "use strict";
 
-const csharp = {
-  lang: "C#",
-  extension: "cshtml",
-  attr: {
-    model: "@model",
-    using: "@using"
-  }
-};
-
-const vb = {
-  lang: "VB",
-  extension: "vbhtml",
-  attr: {
-    model: "@ModelType",
-    using: "@Imports"
+const targets = {
+  csharp: {
+    lang: "C#",
+    extension: "cshtml",
+    attr: {
+      model: "@model",
+      using: "@using"
+    }
+  },
+  vb: {
+    lang: "VB",
+    extension: "vbhtml",
+    attr: {
+      model: "@ModelType",
+      using: "@Imports"
+    }
   }
 };
 
@@ -23,8 +24,7 @@ let _rules;
 class Configuration {
   constructor(opts, rules) {
     const options = typeof opts === "object" ? opts : {};
-    this.target = this._getTargetLang(options);
-    this.extension = this.target === vb.lang ? vb.extension : csharp.extension;
+    this.target = this._getTarget(options);
     this.rules = rules;
   }
 
@@ -32,7 +32,7 @@ class Configuration {
     return _rules.map(rule => {
       rule.output = rule.output || {};
       if (!rule.output.extension) {
-        rule.output.extension = this.extension;
+        rule.output.extension = this.target.extension;
       }
 
       if (rule.template) {
@@ -43,7 +43,9 @@ class Configuration {
 
         const header = configuredHeader ? `${configuredHeader}\n` : "";
 
-        const model = rule.template.model ? `@${rule.template.model}\n` : "";
+        const model = rule.template.model
+          ? `${this.target.attr.model} ${rule.template.model}\n`
+          : "";
 
         const mergedHeader = `${header}${model}`;
 
@@ -61,11 +63,14 @@ class Configuration {
     _rules = Array.isArray(values) ? values : [];
   }
 
-  _getTargetLang(options) {
-    const target = options.target || "C#";
-    return typeof target === "string" && `${target}`.toUpperCase() == vb.lang
-      ? vb.lang
-      : csharp.lang;
+  _getTarget(options) {
+    const targetLang =
+      options.target && typeof options.target === "string"
+        ? options.target
+        : "csharp";
+
+    const target = targets[targetLang.toLowerCase()];
+    return target ? target : targets.csharp;
   }
 }
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,30 +1,13 @@
 "use strict";
 
-const targets = {
-  csharp: {
-    lang: "C#",
-    extension: "cshtml",
-    attr: {
-      model: "@model",
-      using: "@using"
-    }
-  },
-  vb: {
-    lang: "VB",
-    extension: "vbhtml",
-    attr: {
-      model: "@ModelType",
-      using: "@Imports"
-    }
-  }
-};
+const targets = require("./targets");
 
 let _rules;
 
 class Configuration {
   constructor(opts, rules) {
     const options = typeof opts === "object" ? opts : {};
-    this.target = this._getTarget(options);
+    this.target = targets.resolve(options.target || "");
     this.rules = rules;
   }
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -4,7 +4,8 @@ const csharp = {
   lang: "C#",
   extension: "cshtml",
   attr: {
-    model: "@model"
+    model: "@model",
+    using: "@using"
   }
 };
 
@@ -12,7 +13,8 @@ const vb = {
   lang: "VB",
   extension: "vbhtml",
   attr: {
-    model: "@ModelType"
+    model: "@ModelType",
+    using: "@Imports"
   }
 };
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const targets = require("./targets");
+const Header = require("./header");
 
 let _rules;
 
@@ -19,36 +20,19 @@ class Configuration {
       }
 
       if (rule.template) {
-        const configuredHeader =
-          typeof rule.template.header === "function"
-            ? rule.template.header()
-            : rule.template.header;
+        const usings =
+          Array.isArray(rule.template.usings) &&
+          rule.template.usings.map(
+            using => `${this.target.attr.using} ${using}`
+          );
 
-        const header = configuredHeader ? `${configuredHeader}\n` : "";
+        const model =
+          rule.template.model &&
+          `${this.target.attr.model} ${rule.template.model}`;
 
-        const configuredUsings = Array.isArray(rule.template.usings)
-          ? rule.template.usings
-          : [];
+        const header = new Header(rule.template.header, usings, model);
 
-        const usings = configuredUsings.length
-          ? configuredUsings.reduce(
-              (usings, using) =>
-                `${usings}${this.target.attr.using} ${using}\n`,
-              ""
-            )
-          : "";
-
-        const model = rule.template.model
-          ? `${this.target.attr.model} ${rule.template.model}\n`
-          : "";
-
-        const mergedHeader = `${header}${usings}${model}`;
-
-        if (mergedHeader) {
-          rule.template.header = () => {
-            return mergedHeader;
-          };
-        }
+        rule.template.header = header.format();
       }
       return rule;
     });

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -34,6 +34,17 @@ class Configuration {
       if (!rule.output.extension) {
         rule.output.extension = this.extension;
       }
+
+      if (rule.template) {
+        if (rule.template.header) {
+          const configuredHeader = rule.template.header;
+          rule.template.header = () => {
+            return typeof configuredHeader === "function"
+              ? configuredHeader()
+              : configuredHeader;
+          };
+        }
+      }
       return rule;
     });
   }

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,0 +1,38 @@
+"use strict";
+
+class Header {
+  constructor(header, usings, model) {
+    this.header = this._unpackHeader(header);
+    this.usings = this._unpackUsings(usings);
+    this.model = model;
+  }
+
+  format() {
+    const header = this._chunk(this.header);
+    const usings = this._chunk(this.usings);
+    const model = this._chunk(this.model);
+    const formattedHeader = this._merge(header, usings, model);
+    return formattedHeader ? () => formattedHeader : "";
+  }
+
+  _chunk(part) {
+    const chunk = `${part || ""}`;
+    return !chunk ? "" : chunk.endsWith("\n") ? chunk : `${chunk}\n`;
+  }
+
+  _unpackHeader(header) {
+    return typeof header === "function" ? header() : header;
+  }
+
+  _unpackUsings(usings) {
+    return Array.isArray(usings)
+      ? usings.reduce((concatenated, using) => `${concatenated}${using}\n`, "")
+      : "";
+  }
+
+  _merge() {
+    return [].join.call(arguments, "");
+  }
+}
+
+module.exports = Header;

--- a/lib/targets.js
+++ b/lib/targets.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const targets = {
+  csharp: {
+    lang: "C#",
+    extension: "cshtml",
+    attr: {
+      model: "@model",
+      using: "@using"
+    }
+  },
+  vb: {
+    lang: "VB",
+    extension: "vbhtml",
+    attr: {
+      model: "@ModelType",
+      using: "@Imports"
+    }
+  }
+};
+
+function resolve(target) {
+  const key =
+    target && typeof target === "string" ? target.toLowerCase() : "csharp";
+  return targets[key];
+}
+
+module.exports = {
+  resolve
+};

--- a/test/configuration-init-test.js
+++ b/test/configuration-init-test.js
@@ -5,22 +5,22 @@ import Configuration from "../lib/configuration";
 test("default to target C#", t => {
   const config = new Configuration();
 
-  t.is(config.target, "C#");
-  t.is(config.extension, "cshtml");
+  t.is(config.target.lang, "C#");
+  t.is(config.target.extension, "cshtml");
 });
 
 test("can set target in anycase", t => {
   const options = { target: "vB" };
   const config = new Configuration(options);
 
-  t.is(config.target, "VB");
-  t.is(config.extension, "vbhtml");
+  t.is(config.target.lang, "VB");
+  t.is(config.target.extension, "vbhtml");
 });
 
 test("can set target VB", t => {
   const options = { target: "VB" };
   const config = new Configuration(options);
 
-  t.is(config.target, "VB");
-  t.is(config.extension, "vbhtml");
+  t.is(config.target.lang, "VB");
+  t.is(config.target.extension, "vbhtml");
 });

--- a/test/configuration-rule-header-test.js
+++ b/test/configuration-rule-header-test.js
@@ -44,7 +44,7 @@ test("header from function to wrapping function", t => {
   t.is(configuration.rules[0].template.header(), `${header}${EOL}`);
 });
 
-test("model included in header", t => {
+test("@model included in header", t => {
   const model = "a-model";
 
   const configuration = new Configuration(undefined, [
@@ -56,7 +56,22 @@ test("model included in header", t => {
     }
   ]);
 
-  t.is(configuration.rules[0].template.header(), `@${model}${EOL}`);
+  t.is(configuration.rules[0].template.header(), `@model ${model}${EOL}`);
+});
+
+test("@ModelType included in header for target VB", t => {
+  const model = "a-model";
+
+  const configuration = new Configuration({ target: "VB" }, [
+    {
+      test: /asset/,
+      template: {
+        model
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), `@ModelType ${model}${EOL}`);
 });
 
 test("header configuration before model", t => {
@@ -75,6 +90,6 @@ test("header configuration before model", t => {
 
   t.is(
     configuration.rules[0].template.header(),
-    `${header}${EOL}@${model}${EOL}`
+    `${header}${EOL}@model ${model}${EOL}`
   );
 });

--- a/test/configuration-rule-header-test.js
+++ b/test/configuration-rule-header-test.js
@@ -93,3 +93,59 @@ test("header configuration before model", t => {
     `${header}${EOL}@model ${model}${EOL}`
   );
 });
+
+test("@using(s) included in header", t => {
+  const usings = ["a-using", "another-using"];
+  const expected = `@using ${usings[0]}${EOL}@using ${usings[1]}${EOL}`;
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        usings
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), expected);
+});
+
+test("@Import(s) included in header", t => {
+  const usings = ["a-using", "another-using"];
+  const expected = `@Imports ${usings[0]}${EOL}@Imports ${usings[1]}${EOL}`;
+  const configuration = new Configuration({ target: "VB" }, [
+    {
+      test: /asset/,
+      template: {
+        usings
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), expected);
+});
+
+test("usings in the middle", t => {
+  const header = "a-header";
+  const usings = ["a-using", "another-using"];
+  const model = "a-model";
+
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        header: () => header,
+        usings,
+        model
+      }
+    }
+  ]);
+
+  t.is(
+    configuration.rules[0].template.header(),
+    `${header}
+@using ${usings[0]}
+@using ${usings[1]}
+@model ${model}
+`
+  );
+});

--- a/test/configuration-rule-header-test.js
+++ b/test/configuration-rule-header-test.js
@@ -26,7 +26,7 @@ test("header to function", t => {
     }
   ]);
 
-  t.is(configuration.rules[0].template.header(), header);
+  t.is(configuration.rules[0].template.header(), `${header}${EOL}`);
 });
 
 test("header from function to wrapping function", t => {
@@ -41,5 +41,40 @@ test("header from function to wrapping function", t => {
     }
   ]);
 
-  t.is(configuration.rules[0].template.header(), header);
+  t.is(configuration.rules[0].template.header(), `${header}${EOL}`);
+});
+
+test("model included in header", t => {
+  const model = "a-model";
+
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        model
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), `@${model}${EOL}`);
+});
+
+test("header configuration before model", t => {
+  const header = "a-header";
+  const model = "a-model";
+
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        header: () => header,
+        model
+      }
+    }
+  ]);
+
+  t.is(
+    configuration.rules[0].template.header(),
+    `${header}${EOL}@${model}${EOL}`
+  );
 });

--- a/test/configuration-rule-header-test.js
+++ b/test/configuration-rule-header-test.js
@@ -1,0 +1,45 @@
+import test from "ava";
+import { EOL } from "os";
+
+import Configuration from "../lib/configuration";
+
+test("header not required", t => {
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {}
+    }
+  ]);
+
+  t.falsy(configuration.rules[0].template.header);
+});
+
+test("header to function", t => {
+  const header = "a-header";
+
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        header
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), header);
+});
+
+test("header from function to wrapping function", t => {
+  const header = "a-header";
+
+  const configuration = new Configuration(undefined, [
+    {
+      test: /asset/,
+      template: {
+        header: () => header
+      }
+    }
+  ]);
+
+  t.is(configuration.rules[0].template.header(), header);
+});

--- a/test/header-format-test.js
+++ b/test/header-format-test.js
@@ -1,0 +1,37 @@
+import test from "ava";
+import { EOL } from "os";
+
+import Header from "../lib/header";
+
+test("default to blank header", t => {
+  const header = new Header();
+  const formatter = header.format();
+  t.is(formatter, "");
+});
+
+test("header from function to wrapping function", t => {
+  const configuredHeader = () => "a-header";
+
+  const header = new Header(configuredHeader);
+  const formatter = header.format();
+
+  t.is(formatter(), `${configuredHeader()}${EOL}`);
+});
+
+test("model included in header", t => {
+  const model = "a-model";
+
+  const header = new Header(undefined, undefined, model);
+  const formatter = header.format();
+
+  t.is(formatter(), `${model}${EOL}`);
+});
+
+test("usings included in header", t => {
+  const usings = ["a-using", "another-using"];
+
+  const header = new Header(undefined, usings, undefined);
+  const formatter = header.format();
+
+  t.is(formatter(), `${usings[0]}${EOL}${usings[1]}${EOL}`);
+});

--- a/test/targets-resolve-test.js
+++ b/test/targets-resolve-test.js
@@ -1,0 +1,24 @@
+import test from "ava";
+
+import targets from "../lib/targets";
+
+test("default to target C#", t => {
+  const target = targets.resolve();
+
+  t.is(target.lang, "C#");
+  t.is(target.extension, "cshtml");
+});
+
+test("can set target in anycase", t => {
+  const target = targets.resolve("vB");
+
+  t.is(target.lang, "VB");
+  t.is(target.extension, "vbhtml");
+});
+
+test("can set target C#", t => {
+  const target = targets.resolve("csharp");
+
+  t.is(target.lang, "C#");
+  t.is(target.extension, "cshtml");
+});


### PR DESCRIPTION
As mentioned in issue https://github.com/jouni-kantola/razor-partial-views-webpack-plugin/issues/4, header can be configured to contain
* header, free-format string
* usings, array of view's import statements (`@using MyNamespace`/`@Import MyNamespace`)
* model, view model (`@model MyViewModel`/`@ModelType MyViewModel`)

This PR adds functionality to format a header with
```
<header>
<usings>
<model>
```