### PR TITLE
Usage instructions for first major release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,59 +3,85 @@ Plugin for generating ASP.NET Razor partial views for assets built with webpack.
 
 [![Build Status](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin.svg?branch=master)](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin)
 
+## Usage
+`razor-partial-views-webpack-plugin` takes a set of rules for creating `cshtml`/`vbhtml` views, wrapping assets built with webpack.
+
+## Example configuration
+```javascript
+const webpack = require("webpack");
+const path = require("path");
+
+const RazorPartialViewsWebpackPlugin = require("razor-partial-views-webpack-plugin");
+
+module.exports = {
+  entry: {
+    vendor: ["jquery"],
+    app: path.join(__dirname, "index.js")
+  },
+  output: {
+    path: path.join(__dirname, "dist"),
+    publicPath: "/dist/",
+    filename: "[name].[chunkhash].js"
+  },
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin({
+      name: ["vendor", "runtime"]
+    }),
+    new RazorPartialViewsWebpackPlugin({
+      // "csharp" (default) or "vb"
+      target: "chsharp",
+      rules: [
+        {
+          // regex match asset filename(s)
+          // (takes precedence over `name`)
+          test: /(app|vendor).*\.js$/
+        },
+        {
+          // match asset by name
+          name: "runtime",
+          // no attributes in `template` are required
+          template: {
+            // prepend header to view
+            header: () => "<!-- auto generated -->",
+            // usings in view
+            using: ["System", "System.Web"],
+            // view's model
+            model: "dynamic",
+            // append footer to view
+            footer: () => `@* View generated ${new Date().toISOString()} *@`,
+            // if needed, use a custom template
+            path: path.join(__dirname, "templates/custom-template.tmpl"),
+            // in custom template, find & replace placeholder
+            // (default ##URL##/##SOURCE##)
+            replace: /##CONTENT-GOES-HERE##/
+          },
+          // `output` not required, defaults to:
+          // - webpack's output directory
+          // - load asset by URL
+          output: {
+            inline: true,
+            async: false,
+            defer: false,
+            // output view to custom location
+            path: path.join(__dirname, "Views/_GeneratedViews")
+          }
+        }
+      ]
+    })
+  ]
+};
+```
+
+## Compiling views
+When running your ASP.NET web site, the generated views will be compiled. Below follows a few tips to keep in mind:
+- If you run into `Compiler Error Message: CS0103: The name 'model' does not exist in the current context`, this [Stack Overflow answer](https://stackoverflow.com/a/19696998) guides you in the right direction.
+- If you're executing `razor-partial-views-webpack-plugin` on a build server, make sure you've included the generated views' output directory in the artifact.
+
 ## Installation
 - `npm install razor-partial-views-webpack-plugin --save-dev`
 - `yarn add razor-partial-views-webpack-plugin --dev`
 
-## Usage
-`razor-partial-views-webpack-plugin` takes a set of rules for creating `cshtml`/`vbhtml` files wrapping assets built with webpack.
-
-## Example configuration
-```javascript
-// webpack.config.js
-const RazorPartialViewsWebpackPlugin = require("razor-partial-views-webpack-plugin");
-
-const razorViewsConfig = {
-  target: "chsharp", // "csharp" (default) or "vb"
-  rules: [
-    {
-      name: "manifest", // match by asset name
-      test: /manifest.*\.js$/, // ...or filename with regex (takes precedence)
-
-      template: {
-        // none of the attributes in `template` are required
-        header: () => "<!-- top of view -->", // prepend to view
-        // usings for view
-        using: ["namespace1", "namespace2"],
-        // view's model
-        model: "MyViewModel",
-        // append to view
-        footer: () => "\n<!-- bottom of view -->",
-        // if needed, use your own custom template
-        path: path.join(__dirname, "tmpl/inline.tmpl"),
-        // in custom template, what placeholder to find & replace
-        // default "##URL##" or "##SOURCE##"
-        replace: "##HULAHULA##"
-      },
-      output: {
-        // if not specified URL to asset (including `publicPath`)
-        // if none specified, defaults to sync asset
-        inline: true
-        // async: true
-        // defer: true
-      }
-    }
-  ]
-};
-
-module.exports = {
-  /* ... */
-  plugins: [new RazorPartialViewsWebpackPlugin(razorViewsConfig)]
-};
-
-```
-
-`razor-partial-views-webpack-plugin` is an extension of `templated-assets-webpack-plugin`. For richer configuration options and more detailed control, use [templated-assets-webpack-plugin](https://github.com/jouni-kantola/templated-assets-webpack-plugin).
+`razor-partial-views-webpack-plugin` is an extension of `templated-assets-webpack-plugin`. For more configuration options and detailed control, use [templated-assets-webpack-plugin](https://github.com/jouni-kantola/templated-assets-webpack-plugin).
 
 ## Feedback
 * For feedback, bugs or change requests, please use [Issues](https://github.com/jouni-kantola/razor-partial-views-webpack-plugin/issues).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plugin for generating ASP.NET Razor partial views for assets built with webpack.
 [![Build Status](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin.svg?branch=master)](https://travis-ci.org/jouni-kantola/razor-partial-views-webpack-plugin)
 
 ## Usage
-`razor-partial-views-webpack-plugin` takes a set of rules for creating `cshtml`/`vbhtml` views, wrapping assets built with webpack.
+`razor-partial-views-webpack-plugin` takes a set of rules for creating `cshtml`/`vbhtml` views, wrapping assets built with webpack. With the plugin comes templates for scripts and styles, but any type of asset can be used as Razor view source. 
 
 ## Example configuration
 ```javascript
@@ -42,7 +42,7 @@ module.exports = {
           // no attributes in `template` are required
           template: {
             // prepend header to view
-            header: () => "<!-- auto generated -->",
+            header: () => "<!-- a header -->",
             // usings in view
             using: ["System", "System.Web"],
             // view's model
@@ -51,7 +51,7 @@ module.exports = {
             footer: () => `@* View generated ${new Date().toISOString()} *@`,
             // if needed, use a custom template
             path: path.join(__dirname, "templates/custom-template.tmpl"),
-            // in custom template, find & replace placeholder
+            // in custom template, placeholder to find & replace with asset
             // (default ##URL##/##SOURCE##)
             replace: /##CONTENT-GOES-HERE##/
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razor-partial-views-webpack-plugin",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Plugin for generating ASP.NET Razor partial views for assets built with webpack.",
   "main": "index.js",
   "repository": "git@github.com:jouni-kantola/razor-partial-views-webpack-plugin.git",


### PR DESCRIPTION
- Updated readme with `webpack.config.js` example for using `razor-partial-views-webpack-plugin`. Issue: https://github.com/jouni-kantola/razor-partial-views-webpack-plugin/issues/6
- When testing the plugin, output location should be considered. Mentioned this in readme, with guidance where to look for further information. This was uncovered when addressing issue https://github.com/jouni-kantola/razor-partial-views-webpack-plugin/issues/13.
- Bumped version in `package.json` to major. All remaining issues are handled in this PR.