### PR TITLE
Built-in module/nomodule script tag templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node_modules/.bin/eslint .",
+    "lint": "eslint .",
     "test": "ava test/*-test.js",
-    "coverage": "node_modules/.bin/nyc --check-coverage npm test",
-    "qa": "npm run lint & npm run coverage",
-    "example": "node_modules/.bin/webpack --config ./example/webpack.config.js",
+    "coverage": "nyc --check-coverage npm test",
+    "qa": "yarn lint & yarn coverage",
+    "example": "webpack --config ./example/webpack.config.js",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razor-partial-views-webpack-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Plugin for generating ASP.NET Razor partial views for assets built with webpack.",
   "main": "index.js",
   "repository": "git@github.com:jouni-kantola/razor-partial-views-webpack-plugin.git",
@@ -13,7 +13,7 @@
   "author": "Jouni Kantola <jouni@kantola.se>",
   "license": "MIT",
   "dependencies": {
-    "templated-assets-webpack-plugin": "^1.3.0"
+    "templated-assets-webpack-plugin": "^1.3.1"
   },
   "devDependencies": {
     "ava": "^0.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,10 +6178,10 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-templated-assets-webpack-plugin@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-1.3.0.tgz#f6313e212a99847982e7bab4c1f475e5127cfd00"
-  integrity sha512-XPShcz5U25KUnUwBRdgbVGxDN6kE/tSwX1ax/UmaZDzqEUVZ9bsYQE4L5q6Sbd16hVq6tMw/juK7A6RlnypgkA==
+templated-assets-webpack-plugin@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-1.3.1.tgz#60584b08bbd82892329d4fa8671acb50f03b3a3c"
+  integrity sha512-x3S+RZnif0/1TBiYw5EkmmkISywOlmNxbgZgpQbfIuMu57eHlKTQBGPxUEi0UT0n9S6fVgEJh01ZVOKgV8339A==
   dependencies:
     is "^3.2.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Base plugin now comes with functionality for rendering script tags for `type="module"` and `nomodule` attribute.