### PR TITLE
Default output assets for JS and CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razor-partial-views-webpack-plugin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Plugin for generating ASP.NET Razor partial views for assets built with webpack.",
   "main": "index.js",
   "repository": "git@github.com:jouni-kantola/razor-partial-views-webpack-plugin.git",
@@ -13,7 +13,7 @@
   "author": "Jouni Kantola <jouni@kantola.se>",
   "license": "MIT",
   "dependencies": {
-    "templated-assets-webpack-plugin": "^1.3.1"
+    "templated-assets-webpack-plugin": "^1.3.2"
   },
   "devDependencies": {
     "ava": "^0.23.0",

--- a/test/plugin-apply-test.js
+++ b/test/plugin-apply-test.js
@@ -42,3 +42,36 @@ test.cb("emit cshtml asset", t => {
     }
   );
 });
+
+test.cb("default generate templated ", t => {
+  const plugin = new RazorPartialViewsWebpackPlugin();
+
+  webpack(
+    {
+      entry: {
+        asset: path.join(__dirname, "plugin-apply-test-entry.js")
+      },
+      output: {
+        path: path.join(__dirname, "dist")
+      },
+      plugins: [plugin]
+    },
+    (err, stats) => {
+      if (err) {
+        return t.end(err);
+      } else if (stats.hasErrors()) {
+        return t.end(stats.toString());
+      }
+
+      const { compilation } = stats;
+
+      const expected = `<script type="text/javascript" src="/${compilation.chunks[0].files[0]}"></script>${EOL}`;
+
+      const asset = compilation.assets["asset.cshtml"];
+      t.is(asset.source(), expected);
+      t.is(asset.size(), expected.length);
+
+      t.end();
+    }
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,7 +3546,7 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is@^3.2.1:
+is@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
   integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
@@ -6178,12 +6178,12 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-templated-assets-webpack-plugin@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-1.3.1.tgz#60584b08bbd82892329d4fa8671acb50f03b3a3c"
-  integrity sha512-x3S+RZnif0/1TBiYw5EkmmkISywOlmNxbgZgpQbfIuMu57eHlKTQBGPxUEi0UT0n9S6fVgEJh01ZVOKgV8339A==
+templated-assets-webpack-plugin@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-1.3.2.tgz#5d9edac87341f8e7fda142f2246d7c76ddc428fa"
+  integrity sha512-a4OtgHcZqBviDfAh2CX0Ftw3A3TvZHwblYOWQ66w4zXVisA8eeFKkpFLJhSbCYSelEYXWSeu+poB9ibXnd010Q==
   dependencies:
-    is "^3.2.1"
+    is "^3.3.0"
     mkdirp "^0.5.1"
     webpack-sources "^1.0.2"
 


### PR DESCRIPTION
Base plugin no longer require rules, but instead defaults to generating assets for all JS and CSS. Update `templated-assets-webpack-plugin` dependency to use this capability.