### PR TITLE
Base v2 with webpack 5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "mini-css-extract-plugin": "^0.11.2",
     "husky": "^4.3.0",
     "is-thirteen": "^2.0.0",
-    "lint-staged": "^10.3.0",
+    "lint-staged": "^10.4.0",
     "nyc": "^15.1.0",
-    "prettier": "^2.1.1",
+    "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "webpack": "^5.0.0-beta.30",
     "webpack-cli": "^3.3.12"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Jouni Kantola <jouni@kantola.se>",
   "license": "MIT",
   "dependencies": {
-    "templated-assets-webpack-plugin": "^2.0.0-beta.2"
+    "templated-assets-webpack-plugin": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razor-partial-views-webpack-plugin",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Plugin for generating ASP.NET Razor partial views for assets built with webpack.",
   "main": "index.js",
   "repository": "git@github.com:jouni-kantola/razor-partial-views-webpack-plugin.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,10 +3593,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.3.0.tgz#388c3d440590c45c339e7163f669ea69ae90b1e0"
-  integrity sha512-an3VgjHqmJk0TORB/sdQl0CTkRg4E5ybYCXTTCSJ5h9jFwZbcgKIx5oVma5e7wp/uKt17s1QYFmYqT9MGVosGw==
+lint-staged@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.4.0.tgz#d18628f737328e0bbbf87d183f4020930e9a984e"
+  integrity sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -4643,10 +4643,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-ms@^5.0.0:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5501,10 +5501,10 @@ tar@^6.0.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-templated-assets-webpack-plugin@^2.0.0-beta.2:
-  version "2.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-2.0.0-beta.2.tgz#93b34514f56edbdab96a8394fbcd3d1d2ab49e37"
-  integrity sha512-5/YrpmhRYGNMQjS7wBDpLLx9Gbf1QXAM9clytZQKq1l4qqknnpJTfTIorPtJTmNteTR7Mf54qbjj379JzQRFBQ==
+templated-assets-webpack-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/templated-assets-webpack-plugin/-/templated-assets-webpack-plugin-2.0.0.tgz#e57448af58fcc5b9c12d8450a82863ad1a177bd0"
+  integrity sha512-zHx2xmZr8pq7nCZCME+0fGSZCNFuVMoFE50JPnibx3y6YqKSUj5bw+YS09wdeQXpYstpJ7zdYYAcGZ5LKpepcg==
   dependencies:
     is "^3.3.0"
     mkdirp "^1.0.4"


### PR DESCRIPTION
New major of `templated-assets-webpack-plugin` with webpack 5 support. Only a formality, as no larger changes since last beta. 